### PR TITLE
[typo] fix import statement in backtrader/datacache

### DIFF
--- a/backtrader/datacache.py
+++ b/backtrader/datacache.py
@@ -55,7 +55,7 @@ class BaseCache(bt.LineSeries):
 
 
 if True:
-    impor os
+    import os
     import os.path
     import sqlite3
 


### PR DESCRIPTION
2017-12-04:

just pip installed the package and this error popped up so i came here to check it out and open a PR if yall want it! Chances are you might already know about it

    vagrant@deep-learning:~$ sudo pip install backtrader
    Downloading/unpacking backtrader
      Downloading backtrader-1.9.59.122-py2.py3-none-any.whl (411kB): 411kB downloaded
    Installing collected packages: backtrader
    Compiling /tmp/pip_build_root/backtrader/backtrader/datacache.py ...
      File "/tmp/pip_build_root/backtrader/backtrader/datacache.py", line 58
        impor os
            ^
    SyntaxError: invalid syntax