### PR TITLE
added a reference to strategy class to OptReturn

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -1325,7 +1325,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
                         if attrname.startswith('data'):
                             setattr(a, attrname, None)
 
-                oreturn = OptReturn(strat.params, analyzers=strat.analyzers)
+                oreturn = OptReturn(strat.params, analyzers=strat.analyzers, strategycls=type(strat))
                 results.append(oreturn)
 
             return results


### PR DESCRIPTION
PR as follow up to the discussion here:
https://community.backtrader.com/post/4805

This is needed to make visualization of optimization results work in `backtrader_plotting` when using `optreturn=True`.

I know you said you prefer PRs to `backtrader_contrib` but I thought it would not be appropriate for this patch. Feel free to close if you don't like it.