### PR TITLE
Replace self.p.compression to self.compression in analyzer

### DIFF
--- a/backtrader/analyzers/logreturnsrolling.py
+++ b/backtrader/analyzers/logreturnsrolling.py
@@ -106,8 +106,8 @@ class LogReturnsRolling(bt.TimeFrameAnalyzerBase):
         else:
             self._fundmode = self.p.fund
 
-        self._values = collections.deque([float('Nan')] * self.p.compression,
-                                         maxlen=self.p.compression)
+        self._values = collections.deque([float('Nan')] * self.compression,
+                                         maxlen=self.compression)
 
         if self.p.data is None:
             # keep the initial portfolio value if not tracing a data


### PR DESCRIPTION
When I add LogReturnsRolling analyzer without passing a **compression** param using
`cerebro.addanalyzer(backtrader.analyzers.LogReturnsRolling, _name='LogReturnsRolling')`,
it will cause the following error:

```
Traceback (most recent call last):
  File "/Users/xxx/Documents/codes/backtest/backtrade.py", line 221, in <module>
    start_test(')
  File "/Users/xxx/Documents/codes/backtest/backtrade.py", line 198, in start_test
    strategies = cerebro.run()
  File "/usr/local/lib/python3.7/site-packages/backtrader/cerebro.py", line 1127, in run
    runstrat = self.runstrategies(iterstrat)
  File "/usr/local/lib/python3.7/site-packages/backtrader/cerebro.py", line 1264, in runstrategies
    strat._start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/strategy.py", line 375, in _start
    analyzer._start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/analyzer.py", line 313, in _start
    super(TimeFrameAnalyzerBase, self)._start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/analyzer.py", line 194, in _start
    self.start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/analyzers/logreturnsrolling.py", line 109, in start
    self._values = collections.deque([float('Nan')] * self.p.compression,
TypeError: can't multiply sequence by non-int of type 'NoneType'
```

It works well when replaced self.p.compression to self.compression.
