### PR TITLE
[Feature Request] New store functionality - Backfill from a file prior to Live trade 

### DIFF
--- a/backtrader/brokers/__init__.py
+++ b/backtrader/brokers/__init__.py
@@ -40,3 +40,8 @@ try:
     from .oandabroker import OandaBroker
 except ImportError as e:
     pass  # The user may not have something installed
+
+try:
+    from .ccxtbroker import CCXTBroker
+except ImportError as e:
+    pass  # The user may not have something installed

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015, 2016, 2017 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import collections
+from copy import copy
+from datetime import date, datetime, timedelta
+import threading
+import time
+import uuid
+
+import ccxt
+
+from backtrader import BrokerBase, OrderBase, Order
+from backtrader.utils.py3 import with_metaclass, queue, MAXFLOAT
+from backtrader.metabase import MetaParams
+
+class CCXTOrder(OrderBase):
+    def __init__(self, owner, data, ccxt_order):
+        self.owner = owner
+        self.data = data
+        self.ccxt_order = ccxt_order
+        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
+        self.size = float(ccxt_order['info']['original_amount'])
+
+        super(CCXTOrder, self).__init__()
+
+class CCXTBroker(BrokerBase):
+    '''Broker implementation for CCXT cryptocurrency trading library.
+
+    This class maps the orders/positions from CCXT to the
+    internal API of ``backtrader``.
+    '''
+
+    order_types = {Order.Market: 'market',
+                   Order.Limit: 'limit',
+                   Order.Stop: 'stop',
+                   Order.StopLimit: 'stop limit'}
+
+    def __init__(self, exchange, currency, config):
+        super(CCXTBroker, self).__init__()
+
+        self.exchange = getattr(ccxt, exchange)(config)
+        self.currency = currency
+
+        self.notifs = queue.Queue()  # holds orders which are notified
+
+    def getcash(self):
+        return self.exchange.fetch_balance()['free'][self.currency]
+
+    def getvalue(self):
+        return self.exchange.fetch_balance()['total'][self.currency]
+
+    def get_notification(self):
+        try:
+            return self.notifs.get(False)
+        except queue.Empty:
+            return None
+
+    def notify(self, order):
+        self.notifs.put(order)
+
+    def getposition(self, data):
+        currency = data.symbol.split('/')[0]
+        return self.exchange.fetch_balance()['total'][currency]
+
+    def _submit(self, owner, data, exectype, side, amount, price, params):
+        order_type = self.order_types.get(exectype)
+        ccxt_order = self.exchange.create_order(symbol=data.symbol, type=order_type, side=side,
+                                                amount=amount, price=price, params=params)
+        order = CCXTOrder(owner, data, ccxt_order)
+        self.notify(order)
+        return order 
+
+    def buy(self, owner, data, size, price=None, plimit=None,
+            exectype=None, valid=None, tradeid=0, oco=None,
+            trailamount=None, trailpercent=None,
+            **kwargs):
+        return self._submit(owner, data, exectype, 'buy', size, price, kwargs)
+
+    def sell(self, owner, data, size, price=None, plimit=None,
+             exectype=None, valid=None, tradeid=0, oco=None,
+             trailamount=None, trailpercent=None,
+             **kwargs):
+        return self._submit(owner, data, exectype, 'sell', size, price, kwargs)
+
+    def cancel(self, order):
+        return self.exchange.cancel_order(self, order['id'])

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -75,6 +75,12 @@ class CCXTBroker(BrokerBase):
         currency = data.symbol.split('/')[0]
         return self.store.getposition(currency)
 
+    def get_value(self, datas=None, mkt=False, lever=False):
+        return self.store.getvalue(self.currency)
+
+    def get_cash(self):
+        return self.store.getcash(self.currency)
+
     def _submit(self, owner, data, exectype, side, amount, price, params):
         order_type = self.order_types.get(exectype)
         _order = self.store.create_order(symbol=data.symbol, order_type=order_type, side=side,

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -97,3 +97,6 @@ class CCXTBroker(BrokerBase):
 
     def cancel(self, order):
         return self.store.cancel_order(order['id'])
+
+    def get_orders_open(self, safe=False):
+        return self.store.fetch_open_orders()

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -30,8 +30,8 @@ class CCXTOrder(OrderBase):
         self.owner = owner
         self.data = data
         self.ccxt_order = ccxt_order
-        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
-        self.size = float(ccxt_order['info']['original_amount'])
+        self.ordtype = self.Buy if ccxt_order['side'] == 'buy' else self.Sell
+        self.size = float(ccxt_order['amount'])
 
         super(CCXTOrder, self).__init__()
 

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -21,16 +21,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import collections
-from copy import copy
-from datetime import date, datetime, timedelta
-import threading
-import time
-import uuid
-
 from backtrader import BrokerBase, OrderBase, Order
-from backtrader.utils.py3 import with_metaclass, queue, MAXFLOAT
-from backtrader.metabase import MetaParams
+from backtrader.utils.py3 import queue
 from backtrader.stores.ccxtstore import CCXTStore
 
 class CCXTOrder(OrderBase):

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -21,19 +21,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from backtrader import BrokerBase, OrderBase, Order
+from backtrader import BrokerBase, Order
 from backtrader.utils.py3 import queue
-from backtrader.stores.ccxtstore import CCXTStore
-
-class CCXTOrder(OrderBase):
-    def __init__(self, owner, data, ccxt_order):
-        self.owner = owner
-        self.data = data
-        self.ccxt_order = ccxt_order
-        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
-        self.size = float(ccxt_order['info']['original_amount'])
-
-        super(CCXTOrder, self).__init__()
+from backtrader.stores.ccxtstore import CCXTStore, CCXTOrder
 
 class CCXTBroker(BrokerBase):
     '''Broker implementation for CCXT cryptocurrency trading library.
@@ -102,7 +92,7 @@ class CCXTBroker(BrokerBase):
         return self._submit(owner, data, exectype, 'sell', size, price, kwargs)
 
     def cancel(self, order):
-        return self.store.cancel_order(order['id'])
+        return self.store.cancel_order(order)
 
     def get_orders_open(self, safe=False):
         return self.store.fetch_open_orders()

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -30,8 +30,8 @@ class CCXTOrder(OrderBase):
         self.owner = owner
         self.data = data
         self.ccxt_order = ccxt_order
-        self.ordtype = self.Buy if ccxt_order['side'] == 'buy' else self.Sell
-        self.size = float(ccxt_order['amount'])
+        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
+        self.size = float(ccxt_order['info']['original_amount'])
 
         super(CCXTOrder, self).__init__()
 

--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -55,10 +55,10 @@ class CCXTBroker(BrokerBase):
                    Order.Stop: 'stop',
                    Order.StopLimit: 'stop limit'}
 
-    def __init__(self, exchange, currency, config):
+    def __init__(self, exchange, currency, config, retries=5):
         super(CCXTBroker, self).__init__()
 
-        self.store = CCXTStore(exchange, config)
+        self.store = CCXTStore(exchange, config, retries)
 
         self.currency = currency
 

--- a/backtrader/dataseries.py
+++ b/backtrader/dataseries.py
@@ -40,7 +40,7 @@ class TimeFrame(object):
     names = Names  # support old naming convention
 
     @classmethod
-    def getname(cls, tframe, compression=None):
+    def getname(cls, tframe, compression=1):
         tname = cls.Names[tframe]
         if compression > 1 or tname == cls.Names[-1]:
             return tname  # for plural or 'NoTimeFrame' return plain entry

--- a/backtrader/feeds/__init__.py
+++ b/backtrader/feeds/__init__.py
@@ -52,3 +52,8 @@ from .vchartfile import VChartFile
 
 from .rollover import RollOver
 from .chainer import Chainer
+
+try:
+    from .ccxt import CCXT
+except ImportError:
+    pass # The user may not have something installed

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -64,7 +64,7 @@ class CCXT(DataBase):
         self.store = CCXTStore(exchange, config, retries)
 
         self._data = deque() # data queue for price data
-        self._last_id = '' # last processed trade id for ohlcv
+        self._last_id = 0 # last processed trade id for ohlcv
         self._last_ts = 0 # last processed timestamp for ohlcv
 
     def start(self, ):
@@ -136,14 +136,14 @@ class CCXT(DataBase):
                 break
 
     def _load_ticks(self):
-        if self._last_id is None:
+        if self._last_id == 0:
             # first time get the latest trade only
             trades = [self.store.fetch_trades(self.symbol)[-1]]
         else:
             trades = self.store.fetch_trades(self.symbol)
 
         for trade in trades:
-            trade_id = trade['id']
+            trade_id = int(trade['id'])
 
             if trade_id > self._last_id:
                 trade_time = datetime.strptime(trade['datetime'], '%Y-%m-%dT%H:%M:%S.%fZ')

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -89,7 +89,8 @@ class CCXT(DataBase):
         self.ohlcv_limit = ohlcv_limit
 
         self._data = deque() # data queue for price data
-        self._last_id = '' # last processed data id (trade id or timestamp for ohlcv)
+        self._last_id = '' # last processed trade id for ohlcv
+        self._last_ts = 0 # last processed timestamp for ohlcv
 
     def start(self, ):
         super(CCXT, self).start()
@@ -153,9 +154,9 @@ class CCXT(DataBase):
         for ohlcv in self.exchange.fetch_ohlcv(self.symbol, timeframe=granularity,
                                                since=since, limit=limit)[::-1]:
             tstamp = ohlcv[0]
-            if tstamp > self._last_id:
+            if tstamp > self._last_ts:
                 self._data.append(ohlcv)
-                self._last_id = tstamp
+                self._last_ts = tstamp
 
     def _load_ticks(self):
         sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -147,7 +147,11 @@ class CCXT(DataBase):
             since = int((fromdate - datetime(1970, 1, 1)).total_seconds() * 1000)
             limit = None
         else:
-            since = None
+            if 0 < self._last_ts:
+                since = self._last_ts
+            else:
+                since = None
+
             limit = self.ohlcv_limit
 
         sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -112,12 +112,9 @@ class CCXT(DataBase):
             if self._state == self._ST_LIVE:
                 if self._timeframe == bt.TimeFrame.Ticks:
                     return self._load_ticks()
-                elif self.exchange.hasFetchOHLCV:
+                else:
                     self._fetch_ohlcv()
                     return self._load_ohlcv()
-                else:
-                    raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
-                                              self.exchange.name)
             elif self._state == self._ST_HISTORBACK:
                 ret = self._load_ohlcv()
                 if ret:
@@ -135,6 +132,10 @@ class CCXT(DataBase):
 
     def _fetch_ohlcv(self, fromdate=None):
         """Fetch OHLCV data into self._data queue"""
+        if not self.exchange.hasFetchOHLCV:
+            raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
+                                      self.exchange.name)
+
         granularity = self._GRANULARITIES.get((self._timeframe, self._compression))
         if granularity is None:
             raise ValueError("'%s' exchange doesn't support fetching OHLCV data for "

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -57,7 +57,7 @@ class CCXT(DataBase):
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
-    def __init__(self, exchange, symbol, ohlcv_limit=450, config={}, retries=5):
+    def __init__(self, exchange, symbol, ohlcv_limit=None, config={}, retries=5):
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015, 2016, 2017 Daniel Rodriguez
+# Copyright (C) 2017 Ed Bartosh
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from collections import deque
+from datetime import datetime
+from time import sleep
+
+import backtrader as bt
+from backtrader.feed import DataBase
+
+import ccxt
+
+class CCXT(DataBase):
+    """
+    CryptoCurrency eXchange Trading Library Data Feed.
+
+    Params:
+
+      - ``historical`` (default: ``False``)
+
+        If set to ``True`` the data feed will stop after doing the first
+        download of data.
+
+        The standard data feed parameters ``fromdate`` and ``todate`` will be
+        used as reference.
+
+      - ``backfill_start`` (default: ``True``)
+
+        Perform backfilling at the start. The maximum possible historical data
+        will be fetched in a single request.
+    """
+
+    params = (
+        ('historical', False),  # only historical download
+        ('backfill_start', False),  # do backfilling at the start
+    )
+
+    # Supported granularities
+    _GRANULARITIES = {
+        (bt.TimeFrame.Minutes, 1): '1m',
+        (bt.TimeFrame.Minutes, 3): '3m',
+        (bt.TimeFrame.Minutes, 5): '5m',
+        (bt.TimeFrame.Minutes, 15): '15m',
+        (bt.TimeFrame.Minutes, 30): '30m',
+        (bt.TimeFrame.Minutes, 60): '1h',
+        (bt.TimeFrame.Minutes, 90): '90m',
+        (bt.TimeFrame.Minutes, 120): '2h',
+        (bt.TimeFrame.Minutes, 240): '4h',
+        (bt.TimeFrame.Minutes, 360): '6h',
+        (bt.TimeFrame.Minutes, 480): '8h',
+        (bt.TimeFrame.Minutes, 720): '12h',
+        (bt.TimeFrame.Days, 1): '1d',
+        (bt.TimeFrame.Days, 3): '3d',
+        (bt.TimeFrame.Weeks, 1): '1w',
+        (bt.TimeFrame.Weeks, 2): '2w',
+        (bt.TimeFrame.Months, 1): '1M',
+        (bt.TimeFrame.Months, 3): '3M',
+        (bt.TimeFrame.Months, 6): '6M',
+        (bt.TimeFrame.Years, 1): '1y',
+    }
+
+    # States for the Finite State Machine in _load
+    _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
+
+    def __init__(self, exchange, symbol, ohlcv_limit=10):
+        self.exchange = getattr(ccxt, exchange)()
+        self.symbol = symbol
+        self.ohlcv_limit = ohlcv_limit
+
+        self._data = deque() # data queue for price data
+        self._last_id = None # last processed data id (trade id or timestamp for ohlcv)
+
+    def start(self, ):
+        super(CCXT, self).start()
+
+        if self.p.fromdate:
+            self._state = self._ST_HISTORBACK
+            self.put_notification(self.DELAYED)
+
+            self._fetch_ohlcv(self.p.fromdate)
+        else:
+            self._state = self._ST_LIVE
+            self.put_notification(self.LIVE)
+
+    def _load(self):
+        if self._state == self._ST_OVER:
+            return False
+
+        while True:
+            if self._state == self._ST_LIVE:
+                if self._timeframe == bt.TimeFrame.Ticks:
+                    return self._load_ticks()
+                elif self.exchange.hasFetchOHLCV:
+                    self._fetch_ohlcv()
+                    return self._load_ohlcv()
+                else:
+                    raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
+                                              self.exchange.name)
+            elif self._state == self._ST_HISTORBACK:
+                ret = self._load_ohlcv()
+                if ret:
+                    return ret
+                else:
+                    # End of historical data
+                    if self.p.historical:  # only historical
+                        self.put_notification(self.DISCONNECTED)
+                        self._state = self._ST_OVER
+                        return False  # end of historical
+                    else:
+                        self._state = self._ST_LIVE
+                        self.put_notification(self.LIVE)
+                        continue
+
+    def _fetch_ohlcv(self, fromdate=None):
+        """Fetch OHLCV data into self._data queue"""
+        granularity = self._GRANULARITIES.get((self._timeframe, self._compression))
+        if granularity is None:
+            raise ValueError("'%s' exchange doesn't support fetching OHLCV data for "
+                             "time frame %s, comression %s" % \
+                             (self.exchange.name, bt.TimeFrame.getname(self._timeframe),
+                             self._compression))
+
+        if fromdate:
+            since = int((fromdate - datetime(1970, 1, 1)).total_seconds() * 1000)
+            limit = None
+        else:
+            since = None
+            limit = self.ohlcv_limit
+
+        sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
+
+        for ohlcv in self.exchange.fetch_ohlcv(self.symbol, timeframe=granularity,
+                                               since=since, limit=limit)[::-1]:
+            tstamp = ohlcv[0]
+            if tstamp > self._last_id:
+                self._data.append(ohlcv)
+                self._last_id = tstamp
+
+    def _load_ticks(self):
+        sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
+        if self._last_id is None:
+            # first time get the latest trade only
+            trades = [self.exchange.fetch_trades(self.symbol)[-1]]
+        else:
+            trades = self.exchange.fetch_trades(self.symbol)
+
+        for trade in trades:
+            trade_id = trade['id']
+
+            if trade_id > self._last_id:
+                trade_time = datetime.strptime(trade['datetime'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                self._data.append((trade_time, float(trade['price']), float(trade['amount'])))
+                self._last_id = trade_id
+
+        try:
+            trade = self._data.popleft()
+        except IndexError:
+            return # no data in the queue
+
+        trade_time, price, size = trade
+
+        self.lines.datetime[0] = bt.date2num(trade_time)
+        self.lines.open[0] = price
+        self.lines.high[0] = price
+        self.lines.low[0] = price
+        self.lines.close[0] = price
+        self.lines.volume[0] = size
+
+        print("%s: loaded tick: time: %s, price: %s, size: %s" % (self._name, trade_time, price, size))
+
+        return True
+
+    def _load_ohlcv(self):
+        try:
+            ohlcv = self._data.popleft()
+        except IndexError:
+            return  # no data in the queue
+
+        tstamp, open_, high, low, close, volume = ohlcv
+
+        dtime = datetime.utcfromtimestamp(tstamp // 1000)
+
+        self.lines.datetime[0] = bt.date2num(dtime)
+        self.lines.open[0] = open_
+        self.lines.high[0] = high
+        self.lines.low[0] = low
+        self.lines.close[0] = close
+        self.lines.volume[0] = volume
+
+        print("%s: loaded ohlcv:  time: %s, open: %s, high: %s, low: %s, close: %s, volume: %s" % \
+              (self._name, dtime.strftime('%Y-%m-%d %H:%M:%S'), open_, high, low, close, volume))
+
+        return True
+
+    def haslivedata(self):
+        return self._state == self._ST_LIVE and self._data
+
+    def islive(self):
+        return not self.p.historical

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -112,7 +112,7 @@ class CCXT(DataBase):
         if fromdate:
             since = int((fromdate - datetime(1970, 1, 1)).total_seconds() * 1000)
         else:
-            if 0 < self._last_ts:
+            if self._last_ts > 0:
                 since = self._last_ts
             else:
                 since = None
@@ -150,7 +150,7 @@ class CCXT(DataBase):
         try:
             trade = self._data.popleft()
         except IndexError:
-            return # no data in the queue
+            return False # no data in the queue
 
         trade_time, price, size = trade
 
@@ -161,15 +161,13 @@ class CCXT(DataBase):
         self.lines.close[0] = price
         self.lines.volume[0] = size
 
-        print("%s: loaded tick: time: %s, price: %s, size: %s" % (self._name, trade_time, price, size))
-
         return True
 
     def _load_ohlcv(self):
         try:
             ohlcv = self._data.popleft()
         except IndexError:
-            return  # no data in the queue
+            return False # no data in the queue
 
         tstamp, open_, high, low, close, volume = ohlcv
 
@@ -181,9 +179,6 @@ class CCXT(DataBase):
         self.lines.low[0] = low
         self.lines.close[0] = close
         self.lines.volume[0] = volume
-
-        print("%s: loaded ohlcv:  time: %s, open: %s, high: %s, low: %s, close: %s, volume: %s" % \
-              (self._name, dtime.strftime('%Y-%m-%d %H:%M:%S'), open_, high, low, close, volume))
 
         return True
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -121,8 +121,8 @@ class CCXT(DataBase):
 
         while True:
             dlen = len(self._data)
-            for ohlcv in self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
-                                                since=since, limit=limit)[::-1]:
+            for ohlcv in sorted(self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
+                                                       since=since, limit=limit)):
                 if None in ohlcv:
                     continue
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -123,6 +123,9 @@ class CCXT(DataBase):
             dlen = len(self._data)
             for ohlcv in self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
                                                 since=since, limit=limit)[::-1]:
+                if None in ohlcv:
+                    continue
+
                 tstamp = ohlcv[0]
                 if tstamp > self._last_ts:
                     self._data.append(ohlcv)

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -57,11 +57,11 @@ class CCXT(DataBase):
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
-    def __init__(self, exchange, symbol, ohlcv_limit=450, config={}):
+    def __init__(self, exchange, symbol, ohlcv_limit=450, config={}, retries=5):
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit
 
-        self.store = CCXTStore(exchange, config)
+        self.store = CCXTStore(exchange, config, retries)
 
         self._data = deque() # data queue for price data
         self._last_id = '' # last processed trade id for ohlcv

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -24,12 +24,10 @@ from __future__ import (absolute_import, division, print_function,
 
 from collections import deque
 from datetime import datetime
-from time import sleep
 
 import backtrader as bt
 from backtrader.feed import DataBase
-
-import ccxt
+from backtrader.stores.ccxtstore import CCXTStore
 
 class CCXT(DataBase):
     """
@@ -56,44 +54,21 @@ class CCXT(DataBase):
         ('backfill_start', False),  # do backfilling at the start
     )
 
-    # Supported granularities
-    _GRANULARITIES = {
-        (bt.TimeFrame.Minutes, 1): '1m',
-        (bt.TimeFrame.Minutes, 3): '3m',
-        (bt.TimeFrame.Minutes, 5): '5m',
-        (bt.TimeFrame.Minutes, 15): '15m',
-        (bt.TimeFrame.Minutes, 30): '30m',
-        (bt.TimeFrame.Minutes, 60): '1h',
-        (bt.TimeFrame.Minutes, 90): '90m',
-        (bt.TimeFrame.Minutes, 120): '2h',
-        (bt.TimeFrame.Minutes, 240): '4h',
-        (bt.TimeFrame.Minutes, 360): '6h',
-        (bt.TimeFrame.Minutes, 480): '8h',
-        (bt.TimeFrame.Minutes, 720): '12h',
-        (bt.TimeFrame.Days, 1): '1d',
-        (bt.TimeFrame.Days, 3): '3d',
-        (bt.TimeFrame.Weeks, 1): '1w',
-        (bt.TimeFrame.Weeks, 2): '2w',
-        (bt.TimeFrame.Months, 1): '1M',
-        (bt.TimeFrame.Months, 3): '3M',
-        (bt.TimeFrame.Months, 6): '6M',
-        (bt.TimeFrame.Years, 1): '1y',
-    }
-
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
     def __init__(self, exchange, symbol, ohlcv_limit=450, config={}):
-        self.exchange = getattr(ccxt, exchange)(config)
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit
+
+        self.store = CCXTStore(exchange, config)
 
         self._data = deque() # data queue for price data
         self._last_id = '' # last processed trade id for ohlcv
         self._last_ts = 0 # last processed timestamp for ohlcv
 
     def start(self, ):
-        super(CCXT, self).start()
+        DataBase.start(self)
 
         if self.p.fromdate:
             self._state = self._ST_HISTORBACK
@@ -132,16 +107,7 @@ class CCXT(DataBase):
 
     def _fetch_ohlcv(self, fromdate=None):
         """Fetch OHLCV data into self._data queue"""
-        if not self.exchange.hasFetchOHLCV:
-            raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
-                                      self.exchange.name)
-
-        granularity = self._GRANULARITIES.get((self._timeframe, self._compression))
-        if granularity is None:
-            raise ValueError("'%s' exchange doesn't support fetching OHLCV data for "
-                             "time frame %s, comression %s" % \
-                             (self.exchange.name, bt.TimeFrame.getname(self._timeframe),
-                             self._compression))
+        granularity = self.store.get_granularity(self._timeframe, self._compression)
 
         if fromdate:
             since = int((fromdate - datetime(1970, 1, 1)).total_seconds() * 1000)
@@ -154,11 +120,9 @@ class CCXT(DataBase):
         limit = self.ohlcv_limit
 
         while True:
-            sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
-
             dlen = len(self._data)
-            for ohlcv in self.exchange.fetch_ohlcv(self.symbol, timeframe=granularity,
-                                                   since=since, limit=limit)[::-1]:
+            for ohlcv in self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
+                                                since=since, limit=limit)[::-1]:
                 tstamp = ohlcv[0]
                 if tstamp > self._last_ts:
                     self._data.append(ohlcv)
@@ -169,12 +133,11 @@ class CCXT(DataBase):
                 break
 
     def _load_ticks(self):
-        sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
         if self._last_id is None:
             # first time get the latest trade only
-            trades = [self.exchange.fetch_trades(self.symbol)[-1]]
+            trades = [self.store.fetch_trades(self.symbol)[-1]]
         else:
-            trades = self.exchange.fetch_trades(self.symbol)
+            trades = self.store.fetch_trades(self.symbol)
 
         for trade in trades:
             trade_id = trade['id']

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -150,7 +150,7 @@ class CCXT(DataBase):
         try:
             trade = self._data.popleft()
         except IndexError:
-            return False # no data in the queue
+            return None # no data in the queue
 
         trade_time, price, size = trade
 
@@ -167,7 +167,7 @@ class CCXT(DataBase):
         try:
             ohlcv = self._data.popleft()
         except IndexError:
-            return False # no data in the queue
+            return None # no data in the queue
 
         tstamp, open_, high, low, close, volume = ohlcv
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -83,8 +83,8 @@ class CCXT(DataBase):
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
-    def __init__(self, exchange, symbol, ohlcv_limit=450):
-        self.exchange = getattr(ccxt, exchange)()
+    def __init__(self, exchange, symbol, ohlcv_limit=450, config={}):
+        self.exchange = getattr(ccxt, exchange)(config)
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -89,7 +89,7 @@ class CCXT(DataBase):
         self.ohlcv_limit = ohlcv_limit
 
         self._data = deque() # data queue for price data
-        self._last_id = None # last processed data id (trade id or timestamp for ohlcv)
+        self._last_id = '' # last processed data id (trade id or timestamp for ohlcv)
 
     def start(self, ):
         super(CCXT, self).start()

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -62,7 +62,7 @@ class CCXTStore(object):
         self.retries = retries
 
     def get_granularity(self, timeframe, compression):
-        if not self.exchange.hasFetchOHLCV:
+        if not self.exchange.has['fetchOHLCV']:
             raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
                                       self.exchange.name)
 

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -35,8 +35,8 @@ class CCXTOrder(OrderBase):
         self.owner = owner
         self.data = data
         self.ccxt_order = ccxt_order
-        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
-        self.size = float(ccxt_order['info']['original_amount'])
+        self.ordtype = self.Buy if ccxt_order['side'] == 'buy' else self.Sell
+        self.size = float(ccxt_order['amount'])
 
         super(CCXTOrder, self).__init__()
 
@@ -115,8 +115,9 @@ class CCXTStore(object):
 
     @retry
     def create_order(self, symbol, order_type, side, amount, price, params):
-        return self.exchange.create_order(symbol=symbol, type=order_type, side=side,
-                                          amount=amount, price=price, params=params)
+        order = self.exchange.create_order(symbol=symbol, type=order_type, side=side,
+                                           amount=amount, price=price, params=params)
+        return self.exchange.parse_order(order['info'])
 
     @retry
     def cancel_order(self, order):

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -25,7 +25,7 @@ import time
 from functools import wraps
 
 import ccxt
-from ccxt.base.errors import NetworkError
+from ccxt.base.errors import NetworkError, ExchangeError
 
 import backtrader as bt
 
@@ -85,7 +85,7 @@ class CCXTStore(object):
                 time.sleep(self.exchange.rateLimit / 1000)
                 try:
                     return method(self, *args, **kwargs)
-                except NetworkError:
+                except (NetworkError, ExchangeError):
                     if i == self.retries - 1:
                         raise
 

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -22,9 +22,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
-import ccxt
-
 from functools import wraps
+
+import ccxt
 from ccxt.base.errors import NetworkError
 
 import backtrader as bt

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -119,3 +119,7 @@ class CCXTStore(object):
     @retry
     def fetch_ohlcv(self, symbol, timeframe, since, limit):
         return self.exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)
+
+    @retry
+    def fetch_open_orders(self):
+        return self.exchange.fetchOpenOrders()

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -93,11 +93,11 @@ class CCXTStore(object):
 
     @retry
     def getcash(self, currency):
-        return self.exchange.fetch_balance()['free'][currency]
+        return self.exchange.fetch_balance()['free'].get(currency, 0.0)
 
     @retry
     def getvalue(self, currency):
-        return self.exchange.fetch_balance()['total'][currency]
+        return self.exchange.fetch_balance()['total'].get(currency, 0.0)
 
     @retry
     def getposition(self, currency):

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2017 Ed Bartosh <bartosh@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import time
+
+import ccxt
+
+import backtrader as bt
+
+
+class CCXTStore(object):
+    '''API provider for CCXT feed and broker classes.'''
+
+    # Supported granularities
+    _GRANULARITIES = {
+        (bt.TimeFrame.Minutes, 1): '1m',
+        (bt.TimeFrame.Minutes, 3): '3m',
+        (bt.TimeFrame.Minutes, 5): '5m',
+        (bt.TimeFrame.Minutes, 15): '15m',
+        (bt.TimeFrame.Minutes, 30): '30m',
+        (bt.TimeFrame.Minutes, 60): '1h',
+        (bt.TimeFrame.Minutes, 90): '90m',
+        (bt.TimeFrame.Minutes, 120): '2h',
+        (bt.TimeFrame.Minutes, 240): '4h',
+        (bt.TimeFrame.Minutes, 360): '6h',
+        (bt.TimeFrame.Minutes, 480): '8h',
+        (bt.TimeFrame.Minutes, 720): '12h',
+        (bt.TimeFrame.Days, 1): '1d',
+        (bt.TimeFrame.Days, 3): '3d',
+        (bt.TimeFrame.Weeks, 1): '1w',
+        (bt.TimeFrame.Weeks, 2): '2w',
+        (bt.TimeFrame.Months, 1): '1M',
+        (bt.TimeFrame.Months, 3): '3M',
+        (bt.TimeFrame.Months, 6): '6M',
+        (bt.TimeFrame.Years, 1): '1y',
+    }
+
+    def __init__(self, exchange, config):
+        self.exchange = getattr(ccxt, exchange)(config)
+
+    def get_granularity(self, timeframe, compression):
+        if not self.exchange.hasFetchOHLCV:
+            raise NotImplementedError("'%s' exchange doesn't support fetching OHLCV data" % \
+                                      self.exchange.name)
+
+        granularity = self._GRANULARITIES.get((timeframe, compression))
+        if granularity is None:
+            raise ValueError("'%s' exchange doesn't support fetching OHLCV data for "
+                             "time frame %s, comression %s" % \
+                             (self.exchange.name, bt.TimeFrame.getname(timeframe), compression))
+
+        return granularity
+
+    def getcash(self, currency):
+        return self.exchange.fetch_balance()['free'][currency]
+
+    def getvalue(self, currency):
+        return self.exchange.fetch_balance()['total'][currency]
+
+    def getposition(self, currency):
+        return self.getvalue(currency)
+
+    def create_order(self, symbol, order_type, side, amount, price, params):
+        return self.exchange.create_order(symbol=symbol, type=order_type, side=side,
+                                          amount=amount, price=price, params=params)
+
+    def cancel_order(self, order_id):
+        return self.exchange.cancel_order(order_id)
+
+    def fetch_trades(self, symbol):
+        time.sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
+        return self.exchange.fetch_trades(symbol)
+
+    def fetch_ohlcv(self, symbol, timeframe, since, limit):
+        time.sleep(self.exchange.rateLimit / 1000) # time.sleep wants seconds
+        return self.exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit)

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -28,7 +28,17 @@ import ccxt
 from ccxt.base.errors import NetworkError, ExchangeError
 
 import backtrader as bt
+from backtrader import OrderBase
 
+class CCXTOrder(OrderBase):
+    def __init__(self, owner, data, ccxt_order):
+        self.owner = owner
+        self.data = data
+        self.ccxt_order = ccxt_order
+        self.ordtype = self.Buy if ccxt_order['info']['side'] == 'buy' else self.Sell
+        self.size = float(ccxt_order['info']['original_amount'])
+
+        super(CCXTOrder, self).__init__()
 
 class CCXTStore(object):
     '''API provider for CCXT feed and broker classes.'''
@@ -109,8 +119,8 @@ class CCXTStore(object):
                                           amount=amount, price=price, params=params)
 
     @retry
-    def cancel_order(self, order_id):
-        return self.exchange.cancel_order(order_id)
+    def cancel_order(self, order):
+        return self.exchange.cancel_order(order.ccxt_order['id'])
 
     @retry
     def fetch_trades(self, symbol):

--- a/backtrader/stores/ccxtstore.py
+++ b/backtrader/stores/ccxtstore.py
@@ -68,9 +68,13 @@ class CCXTStore(object):
 
         granularity = self._GRANULARITIES.get((timeframe, compression))
         if granularity is None:
+            raise ValueError("backtrader CCXT module doesn't support fetching OHLCV "
+                             "data for time frame %s, comression %s" % \
+                             (bt.TimeFrame.getname(timeframe), compression))
+
+        if self.exchange.timeframes and granularity not in self.exchange.timeframes:
             raise ValueError("'%s' exchange doesn't support fetching OHLCV data for "
-                             "time frame %s, comression %s" % \
-                             (self.exchange.name, bt.TimeFrame.getname(timeframe), compression))
+                             "%s time frame" % (self.exchange.name, granularity))
 
         return granularity
 


### PR DESCRIPTION
Prior starting live trading session, most strategies that use indicators will need some level of historical data backfill to fire up those indicators.
For exchanges that doesn't support OHLCV using 'backfill_start' is not an option.
backfill_start is also limited to the exchange ability to provide long historical data records.

therefore I propose implementing 'backfill_from', which will give the user the ability to load the historical data from a file instead of using a 'backfill_start'.

Notes:
 - example for 'backfill_from' can be found on feed\ibdata.py
 - if exchange doesn't support OHLCV data will be collected as ticks. question is how to stitch with history data in minute resolution?

This discussion has been open to gather ideas for future development