### PR TITLE
date2num fix and rollover live feed support

### DIFF
--- a/backtrader/feeds/rollover.py
+++ b/backtrader/feeds/rollover.py
@@ -169,7 +169,8 @@ class RollOver(bt.with_metaclass(MetaRollOver, bt.DataBase)):
             for i, d_dt in enumerate(zip(self._ds, self._dts)):
                 d, dt = d_dt
                 while dt < dt0:
-                    d.next()
+                    if d.next() is None:
+                        continue
                     self._dts[i] = dt = d.datetime.datetime()
 
             # Move expired future as much as needed

--- a/backtrader/feeds/rollover.py
+++ b/backtrader/feeds/rollover.py
@@ -152,7 +152,10 @@ class RollOver(bt.with_metaclass(MetaRollOver, bt.DataBase)):
 
     def _load(self):
         while self._d is not None:
-            if self._d.next() is False:  # no values from current data src
+            _next = self._d.next()
+            if _next is None:  # no values yet, more will come
+                continue
+            if _next is False:  # no values from current data src
                 if self._ds:
                     self._d = self._ds.pop(0)
                     self._dts.pop(0)

--- a/backtrader/utils/dateintern.py
+++ b/backtrader/utils/dateintern.py
@@ -206,7 +206,7 @@ def date2num(dt, tz=None):
     is a :func:`float`.
     """
     if tz is not None:
-        dt = tz.localize(tz)
+        dt = tz.localize(dt)
 
     if hasattr(dt, 'tzinfo') and dt.tzinfo is not None:
         delta = dt.tzinfo.utcoffset(dt)


### PR DESCRIPTION
date2num has a typo on datetime localization.
rollover cannot distinguish the end of a feed and a live feed with no data yet.