### PR TITLE
PlotScheme: Use fillalpha for alpha of candles

### DIFF
--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -692,6 +692,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                     colorup=self.pinf.sch.barup,
                     colordown=self.pinf.sch.bardown,
                     label=datalabel,
+                    alpha=self.pinf.sch.fillalpha,
                     fillup=self.pinf.sch.barupfill,
                     filldown=self.pinf.sch.bardownfill)
 


### PR DESCRIPTION
The comment in PlotScheme indicates that this was the intended purpose.