### PR TITLE
fix dimension error in plot

### DIFF
--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -448,6 +448,11 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                 # Get both the axis and the data masked
                 lplotarray = lplotarray[lplotmask]
                 xdata = np.array(xdata)[lplotmask]
+            
+            # Make sure both axis are the same size
+            axis_size = min(len(xdata), len(lplotarray))
+            lplotarray = lplotarray[:axis_size]
+            xdata = xdata[:axis_size]
 
             plottedline = pltmethod(xdata, lplotarray, **plotkwargs)
             try:


### PR DESCRIPTION
durning backtrader plot operation I have encounter the following error:

```
  File "/home/jack/backtrader/backtrader/cerebro.py", line 991, in plot
    start=start, end=end, use=use)
  File "/home/jack/backtrader/backtrader/plot/plot.py", line 189, in plot
    self.plotind(None, ptop, subinds=self.dplotsover[ptop])
  File "/home/jack/backtrader/backtrader/plot/plot.py", line 457, in plotind
    plottedline = pltmethod(xdata, lplotarray, **plotkwargs)
  File "/usr/local/lib/python3.5/dist-packages/matplotlib/__init__.py", line 1898, in inner
    return func(ax, *args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/matplotlib/axes/_axes.py", line 1406, in plot
    for line in self._get_lines(*args, **kwargs):
  File "/usr/local/lib/python3.5/dist-packages/matplotlib/axes/_base.py", line 407, in _grab_next_args
    for seg in self._plot_args(remaining, kwargs):
  File "/usr/local/lib/python3.5/dist-packages/matplotlib/axes/_base.py", line 385, in _plot_args
    x, y = self._xy_from_xy(x, y)
  File "/usr/local/lib/python3.5/dist-packages/matplotlib/axes/_base.py", line 244, in _xy_from_xy
    "have shapes {} and {}".format(x.shape, y.shape))
ValueError: x and y must have same first dimension, but have shapes (8621,) and (8620,)
```


The proposed solution make sure/force the dimension of both axis are of same length