### PR TITLE
Prettier (IMHO) non-interactive plotting

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -933,7 +933,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
 
     broker = property(getbroker, setbroker)
 
-    def plot(self, plotter=None, numfigs=1, iplot=True, start=None, end=None,
+    def plot(self, plotter=None, numfigs=1, iplot=False, start=None, end=None,
              width=16, height=9, dpi=300, tight=True, use=None,
              **kwargs):
         '''

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -103,8 +103,8 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
 
     def drawtag(self, ax, x, y, facecolor, edgecolor, alpha=0.9, **kwargs):
 
-        txt = ax.text(x, y, '%.2f' % y, va='center', ha='left',
-                      fontsize=self.pinf.sch.subtxtsize,
+        txt = ax.text(x+1.5, y, '%.2f' % y, va='center', ha='left',
+                      fontsize=self.pinf.sch.subtxttagsize,
                       bbox=dict(boxstyle=tag_box_style,
                                 facecolor=facecolor,
                                 edgecolor=edgecolor,
@@ -132,6 +132,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
         import matplotlib.pyplot as mpyplot
         self.mpyplot = mpyplot
         self.mpyplot.style.use('bmh')
+        matplotlib.rcParams['font.family'] = 'monospace'
 
         self.pinf = PInfo(self.p.scheme)
         self.sortdataindicators(strategy)

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -69,7 +69,7 @@ class PInfo(object):
         self.prop = mfontmgr.FontProperties(size=self.sch.subtxtsize)
 
     def newfig(self, figid, numfig, mpyplot):
-        fig = mpyplot.figure(figid + numfig, figsize=(16,10))
+        fig = mpyplot.figure(figid + numfig, figsize=self.sch.figsize)
         self.figs.append(fig)
         self.daxis = collections.OrderedDict()
         self.vaxis = list()

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -69,7 +69,7 @@ class PInfo(object):
         self.prop = mfontmgr.FontProperties(size=self.sch.subtxtsize)
 
     def newfig(self, figid, numfig, mpyplot):
-        fig = mpyplot.figure(figid + numfig)
+        fig = mpyplot.figure(figid + numfig, figsize=(16,10))
         self.figs.append(fig)
         self.daxis = collections.OrderedDict()
         self.vaxis = list()
@@ -124,11 +124,12 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
 
         if iplot:
             if 'ipykernel' in sys.modules:
-                matplotlib.use('nbagg')
+                matplotlib.use('module://ipykernel.pylab.backend_inline')
 
         # this import must not happen before matplotlib.use
         import matplotlib.pyplot as mpyplot
         self.mpyplot = mpyplot
+        self.mpyplot.style.use('bmh')
 
         self.pinf = PInfo(self.p.scheme)
         self.sortdataindicators(strategy)
@@ -239,7 +240,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
 
             # Put the subplots as indicated by hspace
             fig.subplots_adjust(hspace=self.pinf.sch.plotdist,
-                                top=0.98, left=0.05, bottom=0.05, right=0.95)
+                                top=0.98, left=0.05, bottom=0.05, right=0.9)
 
             laxis = list(self.pinf.daxis.values())
 
@@ -260,6 +261,8 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
             # but the labels from all axis but the last have to be hidden
             for ax in laxis:
                 self.mpyplot.setp(ax.get_xticklabels(), visible=False)
+                for side in ax.spines.values():
+                    side.set_color('0.0')
 
             self.mpyplot.setp(lastax.get_xticklabels(), visible=True,
                               rotation=self.pinf.sch.tickrotation)

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -113,7 +113,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                       zorder=self.pinf.zorder[ax] + 3.0,
                       **kwargs)
 
-    def plot(self, strategy, figid=0, numfigs=1, iplot=True,
+    def plot(self, strategy, figid=0, numfigs=1, iplot=False,
              start=None, end=None, **kwargs):
         # pfillers={}):
         if not strategy.datas:
@@ -122,8 +122,10 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
         if not len(strategy):
             return
 
-        if iplot:
-            if 'ipykernel' in sys.modules:
+        if 'ipykernel' in sys.modules:
+            if iplot:
+                matplotlib.use('nbagg')
+            else:
                 matplotlib.use('module://ipykernel.pylab.backend_inline')
 
         # this import must not happen before matplotlib.use

--- a/backtrader/plot/scheme.py
+++ b/backtrader/plot/scheme.py
@@ -136,7 +136,7 @@ class PlotScheme(object):
         self.volume = True
 
         # Wether to overlay the volume on the data or use a separate subchart
-        self.voloverlay = True
+        self.voloverlay = False
         # Scaling of the volume to the data when plotting as overlay
         self.volscaling = 0.33
         # Pushing overlay volume up for better visibiliy. Experimentation

--- a/backtrader/plot/scheme.py
+++ b/backtrader/plot/scheme.py
@@ -107,20 +107,20 @@ class PlotScheme(object):
 
         # Default plotstyle for the OHLC bars which (line -> line on close)
         # Other options: 'bar' and 'candle'
-        self.style = 'line'
+        self.style = 'candle'
 
         # Default color for the 'line on close' plot
         self.loc = 'black'
         # Default color for a bullish bar/candle (0.75 -> intensity of gray)
-        self.barup = '0.75'
+        self.barup = 'green'
         # Default color for a bearish bar/candle
-        self.bardown = 'red'
+        self.bardown = '0.3'
         # Level of transparency to apply to bars/cancles (NOT USED)
         self.bartrans = 1.0
 
         # Wether the candlesticks have to be filled or be transparent
         self.barupfill = True
-        self.bardownfill = True
+        self.bardownfill = False
 
         # Opacity for the filled candlesticks (1.0 opaque - 0.0 transparent)
         self.baralpha = 1.0
@@ -150,7 +150,7 @@ class PlotScheme(object):
         # Transparency for text labels (NOT USED CURRENTLY)
         self.subtxttrans = 0.66
         # Default font text size for labels on the chart
-        self.subtxtsize = 9
+        self.subtxtsize = 16
 
         # Transparency for the legend (NOT USED CURRENTLY)
         self.legendtrans = 0.25
@@ -169,7 +169,8 @@ class PlotScheme(object):
         self.valuetags = True
 
         # Default color for horizontal lines (see plotinfo.plothlines)
-        self.hlinescolor = '0.66'  # shade of gray
+        # self.hlinescolor = '0.66'  # shade of gray
+        self.hlinescolor = '0.0'  # shade of gray
         # Default style for horizontal lines
         self.hlinesstyle = '--'
         # Default width for horizontal lines

--- a/backtrader/plot/scheme.py
+++ b/backtrader/plot/scheme.py
@@ -153,7 +153,9 @@ class PlotScheme(object):
         # Transparency for text labels (NOT USED CURRENTLY)
         self.subtxttrans = 0.66
         # Default font text size for labels on the chart
-        self.subtxtsize = 16
+        self.subtxtsize = 9
+        # Default font text size for tag
+        self.subtxttagsize = 16
 
         # Transparency for the legend (NOT USED CURRENTLY)
         self.legendtrans = 0.25

--- a/backtrader/plot/scheme.py
+++ b/backtrader/plot/scheme.py
@@ -76,6 +76,9 @@ tab10_index = [3, 0, 2, 1, 2, 4, 5, 6, 7, 8, 9]
 
 class PlotScheme(object):
     def __init__(self):
+        # figure size
+        self.figsize = (16,10)
+
         # to have a tight packing on the chart wether only the x axis or also
         # the y axis have (see matplotlib)
         self.ytight = False


### PR DESCRIPTION
Hi, in the forums I posted a question about how to remove the frame around the plot in a Jupyter notebook: https://community.backtrader.com/topic/1843/how-to-remove-frame-around-the-plot-in-jupyter-notebook

I would like to propose a solution to that.

These are the changes I've made:
1. Added two new arguments to `cerebro.plot()`: `figsize` and `subtxttagsize`.
2. For (my) convenience, I have turned off interactive plotting by default, i.e. `cerebro.plot(iplot=False)`. In a Jupyter notebook, the default backend will fallback to `module://ipykernel.pylab.backend_inline`
3. Also did some aesthetic tweaks to the PlotScheme.

Some of my changes may break some users' code. Please let me know how I can improve. Thank you!