### PR TITLE
Fix `voloverlay=False` from printing the whole DataFrame as legend label

### DIFF
--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -656,7 +656,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
         voloverlay = (self.pinf.sch.voloverlay and pmaster is None)
 
         if not voloverlay:
-            vollabel += ' ({})'.format(data._dataname)
+            vollabel += ' ({})'.format(data._name)
 
         # if self.pinf.sch.volume and self.pinf.sch.voloverlay:
         axdatamaster = None


### PR DESCRIPTION
Fixes this issue: https://community.backtrader.com/topic/1847/volume-plot-of-pandasdata-uses-the-whole-dataframe-as-legend-label/3

For the following code:

```
cerebro.adddata(data)
```

If `data` is an instance of `BacktraderCSVData`, the label for Volume uses the filename of the CSV file (without extension).

If `data` is an instance of `PandasData`, the label for Volume is blank. You will need to supply the `name` argument for `cerebro.addata`.

This pull request is based off your main branch.