### PR TITLE
Fix getvalue() for future like with automargin

### DIFF
--- a/backtrader/brokers/bbroker.py
+++ b/backtrader/brokers/bbroker.py
@@ -440,7 +440,7 @@ class BackBroker(bt.BrokerBase):
             comminfo = self.getcommissioninfo(data)
             position = self.positions[data]
             # use valuesize:  returns raw value, rather than negative adj val
-            if not self.p.shortcash:
+            if (not self.p.shortcash) or (not comminfo.stocklike):
                 dvalue = comminfo.getvalue(position, data.close[0])
             else:
                 dvalue = comminfo.getvaluesize(position.size, data.close[0])

--- a/backtrader/comminfo.py
+++ b/backtrader/comminfo.py
@@ -215,7 +215,7 @@ class CommInfoBase(with_metaclass(MetaParams)):
         '''Returns the value of a position given a price. For future-like
         objects it is fixed at size * margin'''
         if not self._stocklike:
-            return abs(position.size) * self.get_margin(price)
+            return abs(position.size) * self.get_margin(position.price)
 
         size = position.size
         if size >= 0:


### PR DESCRIPTION
broker.getvalue() must not use comminfo.getvaluesize() for non stocklike with automargin.

comminfo.getvalue() must use position.price and not price for non stocklike.

See this issue in the forum:
https://community.backtrader.com/topic/1903/problem-with-automargin-margin-and-expected-pnl

